### PR TITLE
viban-2: Improve in_progress spinner with Braille dots

### DIFF
--- a/bin/viban
+++ b/bin/viban
@@ -147,8 +147,8 @@ CACHED_COL_W=32
 CACHED_MAX_H=22
 CACHED_MAX_TASKS=7
 
-# Spinner for in_progress cards (ASCII to avoid width calculation issues)
-SPINNER_FRAMES=('|' '/' '-' '\')
+# Spinner for in_progress cards (Braille dots - consistent 1-char width)
+SPINNER_FRAMES=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
 SPINNER_IDX=0
 
 update_term_cache() {


### PR DESCRIPTION
## Changes
- Changed spinner from basic ASCII (`| / - \`) to Braille dots (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`)
- Smoother 10-frame animation vs 4-frame ASCII
- Layout calculations unchanged (spinner_w=2)

## Testing
- [x] `viban help` works
- [x] TUI displays spinner correctly for in_progress issues

Resolves: viban-2